### PR TITLE
Add age, City, and Address properties to User class

### DIFF
--- a/Manzili/backend/ManziliApi/Manzili.Core/Entities/User.cs
+++ b/Manzili/backend/ManziliApi/Manzili.Core/Entities/User.cs
@@ -4,6 +4,7 @@ namespace Manzili.Core.Entities
 {
     public class User : IdentityUser<int>
     {
+        public int age { get; set; } // New attribute
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string City { get; set; } // New attribute


### PR DESCRIPTION
The User class in the Manzili.Core.Entities namespace has been updated to include three new attributes: age, City, and Address.

- Added age property to store the user's age.
- Added City property to store the user's city.
- Added Address property to store the user's address.