### PR TITLE
Add UserImage and Note properties; update migrations

### DIFF
--- a/Manzili/backend/ManziliApi/Manzili.Core/Dto/ReviewDto/ProductReviewDto.cs
+++ b/Manzili/backend/ManziliApi/Manzili.Core/Dto/ReviewDto/ProductReviewDto.cs
@@ -5,6 +5,7 @@ public class ProductReviewDto
     public int ProductId { get; set; }
     public int UserId { get; set; }
     public string UserName { get; set; }
+    public string UserImage { get; set; }
     public string ReplyComment { get; set; } = string.Empty;
     public double Rating { get; set; }
     public DateTime CreatedAt { get; set; }

--- a/Manzili/backend/ManziliApi/Manzili.Core/Entities/Cart.cs
+++ b/Manzili/backend/ManziliApi/Manzili.Core/Entities/Cart.cs
@@ -6,6 +6,7 @@ namespace Manzili.Core.Entities
         public int UserId { get; set; }
         public int StoreId { get; set; }
         public DateTime CreatedAt { get; set; }
+        public string Note { get; set; }
 
         // Navigation properties
         public User User { get; set; }

--- a/Manzili/backend/ManziliApi/Manzili.Core/Entities/Product.cs
+++ b/Manzili/backend/ManziliApi/Manzili.Core/Entities/Product.cs
@@ -15,7 +15,6 @@ public class Product
     public int Quantity { get; set; } // Total quantity
     public string State { get; set; } = enProductStatus.Available.ToString();
     public double? Rate { get; set; }
-    public string Note { get; set; }
     public int? CartId { get; set; }
     public List<ProductSize>? Sizes { get; set; } = new List<ProductSize>();
 
@@ -26,6 +25,7 @@ public class Product
 
     // New properties for store name and rate
     public string StoreName => Store?.BusinessName;
+    public string StoreImage => Store?.ImageUrl;
     public double? StoreRate => Store?.Rate;
     public Cart Cart { get; set; }
 }

--- a/Manzili/backend/ManziliApi/Manzili.Core/Services/ICartService .cs
+++ b/Manzili/backend/ManziliApi/Manzili.Core/Services/ICartService .cs
@@ -15,7 +15,7 @@ namespace Manzili.Core.Services
         Task<OperationResult<bool>> IsCartEmptyAsync(int userId);
         Task<OperationResult<bool>> EditCartItemAsync(int userId, int productId, int quantity);
         Task<OperationResult<bool>> DeleteCartItemAsync(int userId, int productId);
-        Task<OperationResult<bool>> AddOrUpdateNoteAsync(int userId, int productId, string note);
+        Task<OperationResult<bool>> AddOrUpdateNoteAsync(int userId, string note);
         Task<OperationResult<bool>> AddOrUpdateShippingAddressAsync(int userId, string address);
         Task<OperationResult<string>> UploadPaymentReceiptAsync(int userId, IFormFile receipt);
         Task<OperationResult<decimal>> CalculateTotalCostAsync(int userId, decimal shippingCost);

--- a/Manzili/backend/ManziliApi/Manzili.EF/Implementaion/CartService.cs
+++ b/Manzili/backend/ManziliApi/Manzili.EF/Implementaion/CartService.cs
@@ -152,10 +152,9 @@ namespace Manzili.Services
 
             return OperationResult<bool>.Success(true, "Cart item removed successfully.");
         }
-        public async Task<OperationResult<bool>> AddOrUpdateNoteAsync(int userId, int productId, string note)
+        public async Task<OperationResult<bool>> AddOrUpdateNoteAsync(int userId, string note)
         {
             var cart = await _context.Carts
-                .Include(c => c.Products)
                 .FirstOrDefaultAsync(c => c.UserId == userId);
 
             if (cart == null)
@@ -163,13 +162,7 @@ namespace Manzili.Services
                 return OperationResult<bool>.Failure("Cart not found.");
             }
 
-            var cartItem = cart.Products.FirstOrDefault(item => item.Id == productId);
-            if (cartItem == null)
-            {
-                return OperationResult<bool>.Failure("Product not found in cart.");
-            }
-
-            cartItem.Note = note;
+            cart.Note = note;
             _context.Carts.Update(cart);
             await _context.SaveChangesAsync();
 

--- a/Manzili/backend/ManziliApi/Manzili.EF/Implementaion/ProductReviewService.cs
+++ b/Manzili/backend/ManziliApi/Manzili.EF/Implementaion/ProductReviewService.cs
@@ -31,6 +31,7 @@ namespace Manzili.Core.Services
                           ProductId = c.ProductId,
                           UserId = c.UserId,
                           UserName = _db.Users.FirstOrDefault(u => u.Id == c.UserId).UserName,
+                          UserImage = _db.Users.FirstOrDefault(u => u.Id == c.UserId).ImageUrl, 
                           ReplyComment = c.ReplyComment,
                           Rating = r.RatingValue,
                           CreatedAt = c.CreatedAt

--- a/Manzili/backend/ManziliApi/Manzili.EF/Migrations/20250323135800_first.Designer.cs
+++ b/Manzili/backend/ManziliApi/Manzili.EF/Migrations/20250323135800_first.Designer.cs
@@ -11,8 +11,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Manzili.EF.Migrations
 {
     [DbContext(typeof(ManziliDbContext))]
-    [Migration("20250321134634_AddCartIdToProduct")]
-    partial class AddCartIdToProduct
+    [Migration("20250323135800_first")]
+    partial class first
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -127,6 +127,65 @@ namespace Manzili.EF.Migrations
                     b.HasIndex("UserId");
 
                     b.ToTable("Favorites");
+                });
+
+            modelBuilder.Entity("Manzili.Core.Entities.Order", b =>
+                {
+                    b.Property<int>("OrderId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("OrderId"));
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
+
+                    b.Property<int>("StoreId")
+                        .HasColumnType("int");
+
+                    b.Property<double>("Total")
+                        .HasColumnType("float");
+
+                    b.Property<int>("UserId")
+                        .HasColumnType("int");
+
+                    b.HasKey("OrderId");
+
+                    b.HasIndex("StoreId");
+
+                    b.ToTable("Orders");
+                });
+
+            modelBuilder.Entity("Manzili.Core.Entities.OrderProduct", b =>
+                {
+                    b.Property<int>("OrderProductId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("OrderProductId"));
+
+                    b.Property<int>("OrderId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Price")
+                        .HasColumnType("int");
+
+                    b.Property<int>("ProductId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Quantity")
+                        .HasColumnType("int");
+
+                    b.HasKey("OrderProductId");
+
+                    b.HasIndex("OrderId");
+
+                    b.HasIndex("ProductId");
+
+                    b.ToTable("OrderProduct");
                 });
 
             modelBuilder.Entity("Manzili.Core.Entities.ProductCategory", b =>
@@ -467,6 +526,10 @@ namespace Manzili.EF.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
+                    b.Property<string>("Note")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<double>("Price")
                         .HasColumnType("float");
 
@@ -624,6 +687,36 @@ namespace Manzili.EF.Migrations
                     b.Navigation("User");
                 });
 
+            modelBuilder.Entity("Manzili.Core.Entities.Order", b =>
+                {
+                    b.HasOne("Manzili.Core.Entities.Store", "Store")
+                        .WithMany()
+                        .HasForeignKey("StoreId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Store");
+                });
+
+            modelBuilder.Entity("Manzili.Core.Entities.OrderProduct", b =>
+                {
+                    b.HasOne("Manzili.Core.Entities.Order", "Order")
+                        .WithMany("OrderProducts")
+                        .HasForeignKey("OrderId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Product", "Product")
+                        .WithMany()
+                        .HasForeignKey("ProductId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Order");
+
+                    b.Navigation("Product");
+                });
+
             modelBuilder.Entity("Manzili.Core.Entities.ProductCategory", b =>
                 {
                     b.HasOne("StoreCategory", "StoreCategory")
@@ -771,6 +864,11 @@ namespace Manzili.EF.Migrations
             modelBuilder.Entity("Manzili.Core.Entities.Cart", b =>
                 {
                     b.Navigation("Products");
+                });
+
+            modelBuilder.Entity("Manzili.Core.Entities.Order", b =>
+                {
+                    b.Navigation("OrderProducts");
                 });
 
             modelBuilder.Entity("Manzili.Core.Entities.ProductCategory", b =>

--- a/Manzili/backend/ManziliApi/Manzili.EF/Migrations/20250323135800_first.cs
+++ b/Manzili/backend/ManziliApi/Manzili.EF/Migrations/20250323135800_first.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Manzili.EF.Migrations
 {
     /// <inheritdoc />
-    public partial class AddCartIdToProduct : Migration
+    public partial class first : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -302,6 +302,29 @@ namespace Manzili.EF.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "Orders",
+                columns: table => new
+                {
+                    OrderId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Total = table.Column<double>(type: "float", nullable: false),
+                    StoreId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders", x => x.OrderId);
+                    table.ForeignKey(
+                        name: "FK_Orders_Stores_StoreId",
+                        column: x => x.StoreId,
+                        principalTable: "Stores",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "StoreCategoryStores",
                 columns: table => new
                 {
@@ -369,6 +392,7 @@ namespace Manzili.EF.Migrations
                     Quantity = table.Column<int>(type: "int", nullable: false),
                     State = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     Rate = table.Column<double>(type: "float", nullable: true),
+                    Note = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     CartId = table.Column<int>(type: "int", nullable: true)
                 },
                 constraints: table =>
@@ -405,6 +429,34 @@ namespace Manzili.EF.Migrations
                     table.PrimaryKey("PK_Image", x => x.Id);
                     table.ForeignKey(
                         name: "FK_Image_Product_ProductId",
+                        column: x => x.ProductId,
+                        principalTable: "Product",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OrderProduct",
+                columns: table => new
+                {
+                    OrderProductId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    OrderId = table.Column<int>(type: "int", nullable: false),
+                    ProductId = table.Column<int>(type: "int", nullable: false),
+                    Price = table.Column<int>(type: "int", nullable: false),
+                    Quantity = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrderProduct", x => x.OrderProductId);
+                    table.ForeignKey(
+                        name: "FK_OrderProduct_Orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "Orders",
+                        principalColumn: "OrderId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OrderProduct_Product_ProductId",
                         column: x => x.ProductId,
                         principalTable: "Product",
                         principalColumn: "Id",
@@ -484,6 +536,21 @@ namespace Manzili.EF.Migrations
                 name: "IX_Image_ProductId",
                 table: "Image",
                 column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderProduct_OrderId",
+                table: "OrderProduct",
+                column: "OrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderProduct_ProductId",
+                table: "OrderProduct",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_StoreId",
+                table: "Orders",
+                column: "StoreId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Product_CartId",
@@ -571,6 +638,9 @@ namespace Manzili.EF.Migrations
                 name: "Image");
 
             migrationBuilder.DropTable(
+                name: "OrderProduct");
+
+            migrationBuilder.DropTable(
                 name: "ProductRatings");
 
             migrationBuilder.DropTable(
@@ -584,6 +654,9 @@ namespace Manzili.EF.Migrations
 
             migrationBuilder.DropTable(
                 name: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "Orders");
 
             migrationBuilder.DropTable(
                 name: "Product");

--- a/Manzili/backend/ManziliApi/Manzili.EF/Migrations/ManziliDbContextModelSnapshot.cs
+++ b/Manzili/backend/ManziliApi/Manzili.EF/Migrations/ManziliDbContextModelSnapshot.cs
@@ -126,6 +126,65 @@ namespace Manzili.EF.Migrations
                     b.ToTable("Favorites");
                 });
 
+            modelBuilder.Entity("Manzili.Core.Entities.Order", b =>
+                {
+                    b.Property<int>("OrderId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("OrderId"));
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
+
+                    b.Property<int>("StoreId")
+                        .HasColumnType("int");
+
+                    b.Property<double>("Total")
+                        .HasColumnType("float");
+
+                    b.Property<int>("UserId")
+                        .HasColumnType("int");
+
+                    b.HasKey("OrderId");
+
+                    b.HasIndex("StoreId");
+
+                    b.ToTable("Orders");
+                });
+
+            modelBuilder.Entity("Manzili.Core.Entities.OrderProduct", b =>
+                {
+                    b.Property<int>("OrderProductId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("OrderProductId"));
+
+                    b.Property<int>("OrderId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Price")
+                        .HasColumnType("int");
+
+                    b.Property<int>("ProductId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Quantity")
+                        .HasColumnType("int");
+
+                    b.HasKey("OrderProductId");
+
+                    b.HasIndex("OrderId");
+
+                    b.HasIndex("ProductId");
+
+                    b.ToTable("OrderProduct");
+                });
+
             modelBuilder.Entity("Manzili.Core.Entities.ProductCategory", b =>
                 {
                     b.Property<int>("Id")
@@ -464,6 +523,10 @@ namespace Manzili.EF.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
+                    b.Property<string>("Note")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<double>("Price")
                         .HasColumnType("float");
 
@@ -621,6 +684,36 @@ namespace Manzili.EF.Migrations
                     b.Navigation("User");
                 });
 
+            modelBuilder.Entity("Manzili.Core.Entities.Order", b =>
+                {
+                    b.HasOne("Manzili.Core.Entities.Store", "Store")
+                        .WithMany()
+                        .HasForeignKey("StoreId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Store");
+                });
+
+            modelBuilder.Entity("Manzili.Core.Entities.OrderProduct", b =>
+                {
+                    b.HasOne("Manzili.Core.Entities.Order", "Order")
+                        .WithMany("OrderProducts")
+                        .HasForeignKey("OrderId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Product", "Product")
+                        .WithMany()
+                        .HasForeignKey("ProductId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Order");
+
+                    b.Navigation("Product");
+                });
+
             modelBuilder.Entity("Manzili.Core.Entities.ProductCategory", b =>
                 {
                     b.HasOne("StoreCategory", "StoreCategory")
@@ -768,6 +861,11 @@ namespace Manzili.EF.Migrations
             modelBuilder.Entity("Manzili.Core.Entities.Cart", b =>
                 {
                     b.Navigation("Products");
+                });
+
+            modelBuilder.Entity("Manzili.Core.Entities.Order", b =>
+                {
+                    b.Navigation("OrderProducts");
                 });
 
             modelBuilder.Entity("Manzili.Core.Entities.ProductCategory", b =>

--- a/Manzili/backend/ManziliApi/ManziliApi/appsettings.json
+++ b/Manzili/backend/ManziliApi/ManziliApi/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=db13966.public.databaseasp.net; Database=db13966; User Id=db13966; Password=4Rb#X+6og2L_; Encrypt=False; MultipleActiveResultSets=True;"
+    "DefaultConnection": "Server=.; Database=db12; Integrated Security=True; TrustServerCertificate=True;"
   },
 
 


### PR DESCRIPTION
- Updated `ProductReviewDto` to include `UserImage`.
- Added `Note` property to `Cart` class.
- Removed `Note` from `Product` and added `StoreImage`.
- Modified `ICartService` to change `AddOrUpdateNoteAsync` method signature.
- Updated `CartService` to set `Note` directly on `Cart`.
- Adjusted `ProductReviewService` to utilize new `UserImage`.
- Cleaned up migration files by removing unnecessary code.
- Updated `ManziliDbContextModelSnapshot` to include new `Order` and `OrderProduct` entities.
- Changed database connection string in `appsettings.json` to local SQL Server.
- Added new migration for `Orders` and `OrderProduct` tables.